### PR TITLE
Extend timeouts in SAM-BA

### DIFF
--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -48,7 +48,6 @@ using namespace std;
 #define CAN         0x18
 #define START       'C'
 
-#define TIMEOUT_QUICK   100
 #define TIMEOUT_NORMAL  1000
 #define TIMEOUT_LONG    5000
 
@@ -75,7 +74,7 @@ Samba::init()
 {
     uint8_t cmd[3];
 
-    _port->timeout(TIMEOUT_QUICK);
+    _port->timeout(TIMEOUT_NORMAL);
 
     // Flush garbage
     uint8_t dummy[1024];
@@ -564,7 +563,7 @@ Samba::version()
     cmd[1] = '#';
     _port->write(cmd, 2);
 
-    _port->timeout(TIMEOUT_QUICK);
+    _port->timeout(TIMEOUT_NORMAL);
     size = _port->read(cmd, sizeof(cmd) - 1);
     _port->timeout(TIMEOUT_NORMAL);
     if (size <= 0)
@@ -598,7 +597,7 @@ Samba::identifyChip()
     cmd[1] = '#';
     _port->write(cmd, 2);
 
-    _port->timeout(TIMEOUT_QUICK);
+    _port->timeout(TIMEOUT_NORMAL);
     size = _port->read(cmd, sizeof(cmd) - 1);
     _port->timeout(TIMEOUT_NORMAL);
     if (size <= 0)
@@ -657,7 +656,7 @@ Samba::writeBuffer(uint32_t src_addr, uint32_t dst_addr, uint32_t size)
     int l = snprintf((char*) cmd, sizeof(cmd), "Y%08X,0#", src_addr);
     if (_port->write(cmd, l) != l)
         throw SambaError();
-    _port->timeout(TIMEOUT_QUICK);
+    _port->timeout(TIMEOUT_NORMAL);
     cmd[0] = 0;
     _port->read(cmd, 3); // Expects "Y\n\r"
     _port->timeout(TIMEOUT_NORMAL);


### PR DESCRIPTION
This PR implements idea proposed in https://github.com/arduino/arduino-ide/issues/366, namely increases timeouts in the SAM-BA communication in order to allow USB/IP bases devices to be handled correctly.