### PR TITLE
Fix MacOS write error caused by unflushed buffer

### DIFF
--- a/src/PosixSerialPort.cpp
+++ b/src/PosixSerialPort.cpp
@@ -296,7 +296,7 @@ PosixSerialPort::put(int c)
 void
 PosixSerialPort::flush()
 {
-    fsync(_devfd);
+    tcdrain(_devfd);
 }
 
 bool


### PR DESCRIPTION
This change is actually a cherry-picked code change from a pull request to [shumatech/BOSSA](https://github.com/shumatech/BOSSA).  Special thanks to @kaysievers for this code (see issues: [Bossa 1.9.1 occasionally fails mid-download #120](https://github.com/shumatech/BOSSA/issues/120) and the subsequent resolution in [Pull Request #150](https://github.com/shumatech/BOSSA/pull/150))

This change resolved an issue where (I suppose) flash has not been properly erased prior to writing the new code.  This results in a verify error and requires code to be re-flashed to the SAMD21.

PosixSerialPort: Call tcdrain() to write serial data 