### PR TITLE
WinSerialPort: Set DTR behavior explicitly

### DIFF
--- a/src/WinSerialPort.cpp
+++ b/src/WinSerialPort.cpp
@@ -98,7 +98,7 @@ WinSerialPort::open(int baud, int data, SerialPort::Parity parity, SerialPort::S
     }
 
     dcbSerialParams.BaudRate = baud;
-
+    dcbSerialParams.fDtrControl = DTR_CONTROL_DISABLE;
     dcbSerialParams.ByteSize = data;
 
     switch (parity)


### PR DESCRIPTION
Some serial terminal applications apparently change the default DTR behavior ("turn off and keep off"); this causes BOSSA to fail, e.g. on the Arduino Due, until the parameter is reset or the serial device is disconnected and reconnected. Make BOSSA set this parameter explicitly.